### PR TITLE
- fix#266: ricerca per cognome in verifica stato pcto

### DIFF
--- a/src/lib/components/layout/nav_bar.svelte
+++ b/src/lib/components/layout/nav_bar.svelte
@@ -5,7 +5,7 @@
 	<div class="container-fluid">
 		<!-- logo -->
 		<h1 class="navbar-brand navbar-brand-autodark">
-			<a href=".">
+			<a href="/">
 				<img
                     class="logo"
 					src="/img/logo_rettangolare_bianco_small.png"

--- a/src/routes/pcto/verifica_stato/+page.svelte
+++ b/src/routes/pcto/verifica_stato/+page.svelte
@@ -17,9 +17,6 @@
     let show_error_mex = false;
     let user_found = false;
     let pctos = [];
-    // let totale_ore_totali = 0;
-    // let totale_ore_approvate = 0;
-    // let totale_ore_contabilizzate = 0;
 
     function show_error_message() {
         setTimeout(() => {
@@ -31,22 +28,23 @@
     }
 
     async function verifica_studente() {
-        cognome = cognome[0].toUpperCase().concat(cognome.slice(1).toLowerCase());
-        nome = nome[0].toUpperCase().concat(nome.slice(1).toLowerCase());
+        cognome = cognome ? cognome[0].toUpperCase().concat(cognome.slice(1).toLowerCase()) : '';
+        nome = nome ? nome[0].toUpperCase().concat(nome.slice(1).toLowerCase()) : '';
         
-        console.log(cognome, nome)
         const get_pcto_status = await fetch(`/pcto/verifica_stato?cognome=${cognome}&nome=${nome}`);
         let stato_pcto = await get_pcto_status.json();
+
         pctos = [];
         user_found = false;
 
-        if(stato_pcto.length == 0) {
+        if(stato_pcto.length != 1) {
             show_error_mex = true;
             user_found = false;
         } else {
-            pctos = build_table_row(stato_pcto[0]);
-            found_cognome = cognome;
-            found_nome = nome;
+            let result = stato_pcto[0];
+            pctos = build_table_row(result);
+            found_cognome = result.cognome;
+            found_nome = result.nome;
             nome = '';
             cognome = '';
             //questo è un hack necessario per far visualizzare 
@@ -116,7 +114,7 @@
 {#if show_error_mex}
     {show_error_message()}
     <div class="error-mex {show_error_mex ? '' : 'hidden'}">
-        L'utente {cognome} {nome} non è presente nel sistema
+        Prova ad essere più specifico nella ricerca
     </div>
 {/if}
 
@@ -151,7 +149,7 @@
             <div class="col-lg-2">
                 <div class="mb-3">
                     <label class="form-label">&nbsp;</label>
-                    <button class="btn btn-success ms-auto" on:click={verifica_studente} disabled={cognome.length == 0 || nome.length ==0}>
+                    <button class="btn btn-success ms-auto" on:click={verifica_studente} disabled={cognome.length == 0 && nome.length ==0}>
 						<i class="ti ti-zoom-check icon" />
 							<b>Verifica</b>
 					</button>

--- a/src/routes/pcto/verifica_stato/+server.js
+++ b/src/routes/pcto/verifica_stato/+server.js
@@ -26,13 +26,16 @@ export async function GET({ request, url, locals }) {
     
     let cognome = url.searchParams.get("cognome");
     let nome = url.searchParams.get("nome");
+    let whereobj = {};
+
+    if(cognome)
+        whereobj['cognome'] = cognome;
+    if(nome)
+        whereobj['nome'] = nome;
     
     try {
         const studente = await SARP.utente.findMany({
-            where: {
-                cognome: cognome,
-                nome: nome
-            },
+            where: whereobj,
             include: {
                 iscritto: {
                     include: {


### PR DESCRIPTION
- ora è possibile fare una verifica stato PCTO cercando solo per nome o solo per cognome
- se il risultato è diverso da un solo utente viene chiesto di essere più specifici nella ricerca