### PR TITLE
- fix#280: PCTO Stage presenze solo se PCTO valido

### DIFF
--- a/src/routes/pcto/presenze/+page.server.js
+++ b/src/routes/pcto/presenze/+page.server.js
@@ -37,6 +37,7 @@ export async function load({ locals }) {
 		});
 
         const stages = await SARP.pcto_Pcto.findMany({
+            where: { firma_pcto: true},
 			orderBy: [{ titolo: 'asc' }],
 			include: {
 				offertoDa: true,


### PR DESCRIPTION
- le presenze possono essere create solo per i PCTO con tutti i documenti firmati e approvati dalla segreteria