### PR TITLE
Show class in programmazione_docenti modal

### DIFF
--- a/src/routes/programmazione/docente/+page.svelte
+++ b/src/routes/programmazione/docente/+page.svelte
@@ -24,7 +24,7 @@
     let classi = data.insegnamenti.map((insegnamento) => insegnamento.classe);
 	let materie = data.insegnamenti.map((insegnamento) => insegnamento.materia);
 
-	/* Page properties */
+    /* Page properties */
 	$page_action_title = '';
 	$page_pre_title = 'Programma annuale';
 	$page_title = 'Programmazione docente';
@@ -336,7 +336,7 @@
                                 bind:value={form_values.classe}
                             >
                                 {#each classi as classe}
-                                    <option value={classe.id[0]}>{classe.classe}</option>
+                                    <option value={classe.id}>{classe.classe}</option>
                                 {/each}
                             </select>
                         </div>


### PR DESCRIPTION
Per qualche ragione(forse in una precedente versione era così?) l'id della classe veniva trattato come array.

Questa pull request risolve questo problema estetico