### PR TITLE
Fix MODULE_NOT_FOUND when running vite server

### DIFF
--- a/src/js/helper.js
+++ b/src/js/helper.js
@@ -7,7 +7,6 @@ import { browser } from '$app/environment';
 import { mb_type, mb_color, mb_title, mb_message, mb_show } from '$js/store';
 import tippy from 'tippy.js';
 import 'tippy.js/dist/tippy.css'; 
-import log from 'framework7-cli/utils/log';
 
 // Istanzia il logger in funzione di dove viene chiamato
 let logger = browser ? new Logger('client') : new Logger('server');


### PR DESCRIPTION
Importiamo log da framework7-cli, tuttavia questa funzione non viene mai chiamata e il modulo non è presente nel package.json causando un'errore quando si prova ad avviare SARP. Rimuovo log da framework7-cli dato che non viene usato.